### PR TITLE
fix: honor management-policy for create/update in reconcile worker

### DIFF
--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -428,7 +428,14 @@ func (c *Controller) handleObserve(ctx context.Context, ref objectref.ObjectRef)
 		return err
 	}
 
-	if !observation.ResourceExists {
+	// The pending create/update is gated by the resource's management policy
+	// (krateo.io/management-policy), mirroring provider-runtime: a create only
+	// happens when meta.ShouldCreate is true, an update only when
+	// meta.ShouldUpdate is true. When the policy disallows the pending action
+	// (e.g. "observe", "observe-delete") we fall through to the success/no-op
+	// path instead of enqueueing it. Delete is gated separately via
+	// meta.ShouldDelete in processNextItem.
+	if !observation.ResourceExists && meta.ShouldCreate(el) {
 		item := ctrlevent.Event{
 			EventType: ctrlevent.Create,
 			ObjectRef: objectref.ObjectRef{
@@ -444,7 +451,7 @@ func (c *Controller) handleObserve(ctx context.Context, ref objectref.ObjectRef)
 			Priority:    HighPriority,
 		}, item)
 		return nil
-	} else if !observation.ResourceUpToDate {
+	} else if observation.ResourceExists && !observation.ResourceUpToDate && meta.ShouldUpdate(el) {
 		item := ctrlevent.Event{
 			EventType: ctrlevent.Update,
 			ObjectRef: objectref.ObjectRef{
@@ -460,23 +467,32 @@ func (c *Controller) handleObserve(ctx context.Context, ref objectref.ObjectRef)
 			Priority:    HighPriority,
 		}, item)
 		return nil
+	}
+
+	// Either the resource is up to date, or the pending create/update is not
+	// allowed by the management policy. In all cases this is a no-op success.
+	if !observation.ResourceExists && !meta.ShouldCreate(el) {
+		log.Debug("Resource does not exist but creation is not allowed by the management policy; skipping create")
+	} else if observation.ResourceExists && !observation.ResourceUpToDate && !meta.ShouldUpdate(el) {
+		log.Debug("Resource is not up to date but update is not allowed by the management policy; skipping update")
 	} else {
-		err = unstructuredtools.SetConditions(el, condition.ReconcileSuccess())
-		if err != nil {
-			log.Error(err, "Cannot set condition")
-			c.recordEvent(el, event.Warning(reasonCannotSetConditions, actionUpdateManagedResource, err))
-			return err
-		}
-		el, err = tools.UpdateStatus(ctx, el, tools.UpdateOptions{
-			Pluralizer:    c.pluralizer,
-			DynamicClient: c.dynamicClient,
-		})
-		if err != nil {
-			log.Error(err, "Cannot update status")
-			c.recordEvent(el, event.Warning(reasonCannotUpdateManaged, actionUpdateManagedResource, err))
-			return err
-		}
 		log.Info("External resource is up to date")
+	}
+
+	err = unstructuredtools.SetConditions(el, condition.ReconcileSuccess())
+	if err != nil {
+		log.Error(err, "Cannot set condition")
+		c.recordEvent(el, event.Warning(reasonCannotSetConditions, actionUpdateManagedResource, err))
+		return err
+	}
+	el, err = tools.UpdateStatus(ctx, el, tools.UpdateOptions{
+		Pluralizer:    c.pluralizer,
+		DynamicClient: c.dynamicClient,
+	})
+	if err != nil {
+		log.Error(err, "Cannot update status")
+		c.recordEvent(el, event.Warning(reasonCannotUpdateManaged, actionUpdateManagedResource, err))
+		return err
 	}
 
 	return nil

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -279,6 +279,112 @@ func TestHandleObserve_QueuesCreateAndUpdateAndReturnsError(t *testing.T) {
 	require.Equal(t, observeErr, err)
 }
 
+// TestHandleObserve_ManagementPolicyGatesCreateAndUpdate verifies that the
+// management-policy annotation suppresses the create/update events that
+// handleObserve would otherwise enqueue, mirroring provider-runtime's
+// ShouldCreate/ShouldUpdate gating.
+func TestHandleObserve_ManagementPolicyGatesCreateAndUpdate(t *testing.T) {
+	cases := []struct {
+		name             string
+		managementPolicy string
+		observeExists    bool
+		observeUpToDate  bool
+		wantEnqueued     bool
+		wantEventType    ctrlevent.EventType
+	}{
+		{
+			name:             "observe blocks create",
+			managementPolicy: meta.ManagementPolicyObserve,
+			observeExists:    false,
+			wantEnqueued:     false,
+		},
+		{
+			name:             "observe blocks update",
+			managementPolicy: meta.ManagementPolicyObserve,
+			observeExists:    true,
+			observeUpToDate:  false,
+			wantEnqueued:     false,
+		},
+		{
+			name:             "observe-delete blocks create",
+			managementPolicy: meta.ManagementPolicyObserveDelete,
+			observeExists:    false,
+			wantEnqueued:     false,
+		},
+		{
+			name:             "observe-delete blocks update",
+			managementPolicy: meta.ManagementPolicyObserveDelete,
+			observeExists:    true,
+			observeUpToDate:  false,
+			wantEnqueued:     false,
+		},
+		{
+			name:             "observe-create-update allows create",
+			managementPolicy: meta.ManagementPolicyObserveCreateUpdate,
+			observeExists:    false,
+			wantEnqueued:     true,
+			wantEventType:    ctrlevent.Create,
+		},
+		{
+			name:             "observe-create-update allows update",
+			managementPolicy: meta.ManagementPolicyObserveCreateUpdate,
+			observeExists:    true,
+			observeUpToDate:  false,
+			wantEnqueued:     true,
+			wantEventType:    ctrlevent.Update,
+		},
+		{
+			name:             "default (no annotation) allows create",
+			managementPolicy: "",
+			observeExists:    false,
+			wantEnqueued:     true,
+			wantEventType:    ctrlevent.Create,
+		},
+		{
+			name:             "default (no annotation) allows update",
+			managementPolicy: "",
+			observeExists:    true,
+			observeUpToDate:  false,
+			wantEnqueued:     true,
+			wantEventType:    ctrlevent.Update,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sid, err := shortid.New(1, shortid.DefaultABC, 2342)
+			require.NoError(t, err)
+			opts := createTestOptions()
+			ctrl, err := New(sid, opts)
+			require.NoError(t, err)
+
+			obj := createTestUnstructured(fmt.Sprintf("mp-%d", i), opts.Namespace)
+			if tc.managementPolicy != "" {
+				obj.SetAnnotations(map[string]string{meta.AnnotationKeyManagementPolicy: tc.managementPolicy})
+			}
+			_, err = opts.Client.Resource(opts.GVR).Namespace(opts.Namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			ctrl.SetExternalClient(&fakeExternalClient{ObserveExists: tc.observeExists, ObserveUpToDate: tc.observeUpToDate})
+			ref := objectref.ObjectRef{APIVersion: obj.GetAPIVersion(), Kind: obj.GetKind(), Name: obj.GetName(), Namespace: obj.GetNamespace()}
+			require.NoError(t, ctrl.handleObserve(context.TODO(), ref))
+
+			if !tc.wantEnqueued {
+				require.Equal(t, 0, ctrl.queue.Len(), "management policy %q should suppress the event", tc.managementPolicy)
+				return
+			}
+
+			require.Equal(t, 1, ctrl.queue.Len(), "expected exactly one event to be enqueued")
+			item, _, _ := ctrl.queue.GetWithPriority()
+			ev, ok := item.(ctrlevent.Event)
+			require.True(t, ok)
+			require.Equal(t, tc.wantEventType, ev.EventType)
+			ctrl.queue.Done(item)
+			ctrl.queue.Forget(item)
+		})
+	}
+}
+
 func TestHandleCreate_SuccessAndFailure_SetAnnotationsAndConditions(t *testing.T) {
 	sid, err := shortid.New(1, shortid.DefaultABC, 2342)
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

The reconcile worker only gated the **delete** action against the management
policy (`meta.ShouldDelete` in `processNextItem`). The `krateo.io/management-policy`
values that should suppress writes were therefore **not enforced for create/update**:
`handleObserve` enqueued a `Create` event whenever `Observe` reported the resource
missing, and an `Update` event whenever it reported the resource out of date —
regardless of policy.

This diverged from the sibling library **provider-runtime**, which gates all three
actions (`ShouldCreate` / `ShouldUpdate` / `ShouldDelete`). The two runtimes are
meant to behave identically from a resource-lifecycle standpoint, so this was a bug.

## Fix

`pkg/controller/worker.go` — `handleObserve` now gates the enqueued actions:

- `Create` is enqueued only when `!ResourceExists && meta.ShouldCreate(el)`
- `Update` is enqueued only when `ResourceExists && !ResourceUpToDate && meta.ShouldUpdate(el)`

When the pending action is disallowed by the policy (e.g. `observe`, `observe-delete`),
`handleObserve` falls through to the existing success/no-op path: it sets
`ReconcileSuccess` and updates status instead of enqueueing the action.
`Delete` continues to be gated by `meta.ShouldDelete` as before.

## Tests

Adds `TestHandleObserve_ManagementPolicyGatesCreateAndUpdate`, a table-driven test
covering `observe`, `observe-delete`, `observe-create-update` and the default
(no annotation) policy across both the create and update paths.

`go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)